### PR TITLE
RAIN-1586(Common Pay :: Arrears tax heads should not be displayed in the common pay screen if Arrears are not available for the modules.)

### DIFF
--- a/data/pb/common-masters/uiCommonPay.json
+++ b/data/pb/common-masters/uiCommonPay.json
@@ -7,6 +7,7 @@
       "headerBandLabel": "PT_COMMON_TABLE_COL_PT_ID",
       "receiptKey": "property-receipt",
       "billKey": "property-bill",
+      "arrears": true,
       "buttons": [
         {
           "label": "COMMON_BUTTON_HOME",
@@ -20,6 +21,7 @@
       "headerBandLabel": "PTM_COMMON_TABLE_COL_PT_ID",
       "receiptKey": "property-receipt",
       "billKey": "property-bill",
+      "arrears": true,
       "buttons": [
         {
           "label": "COMMON_BUTTON_HOME",
@@ -33,6 +35,7 @@
       "headerBandLabel": "PAYMENT_COMMON_CONSUMER_CODE",
       "receiptKey": "tradelicense-receipt",
       "billKey": "tradelicense-bill",
+      "arrears": false,
       "buttons": [
         {
           "label": "COMMON_BUTTON_HOME",
@@ -46,6 +49,7 @@
       "headerBandLabel": "PAYMENT_COMMON_CONSUMER_CODE",
       "receiptKey": "consolidatedreceipt",
       "billKey": "consolidatedbill",
+      "arrears": true,
       "buttons": [
         {
           "label": "COMMON_BUTTON_HOME",
@@ -59,6 +63,7 @@
       "headerBandLabel": "PAYMENT_COMMON_CONSUMER_CODE",
       "receiptKey": "consolidatedreceipt",
       "billKey": "consolidatedbill",
+      "arrears": true,
       "buttons": [
         {
           "label": "COMMON_BUTTON_HOME",
@@ -72,6 +77,7 @@
       "headerBandLabel": "PAYMENT_COMMON_CONSUMER_CODE",
       "receiptKey": "consolidatedreceipt",
       "billKey": "consolidatedbill",
+      "arrears": true,
       "buttons": [
         {
           "label": "COMMON_BUTTON_HOME",
@@ -85,6 +91,7 @@
       "headerBandLabel": "PAYMENT_COMMON_CONSUMER_CODE",
       "receiptKey": "consolidatedreceipt",
       "billKey": "consolidatedbill",
+      "arrears": false,
       "buttons": [
         {
           "label": "COMMON_BUTTON_HOME",
@@ -98,6 +105,7 @@
       "headerBandLabel": "PAYMENT_COMMON_CONSUMER_CODE",
       "receiptKey": "consolidatedreceipt",
       "billKey": "consolidatedbill",
+      "arrears": true,
       "buttons": [
         {
           "label": "COMMON_BUTTON_HOME",
@@ -111,6 +119,7 @@
       "headerBandLabel": "PAYMENT_COMMON_CONSUMER_CODE",
       "receiptKey": "ws-onetime-receipt",
       "billKey": "ws-bill",
+      "arrears": true,
       "buttons": [
         {
           "label": "COMMON_BUTTON_HOME",
@@ -124,6 +133,7 @@
       "headerBandLabel": "PAYMENT_COMMON_CONSUMER_CODE",
       "receiptKey": "ws-onetime-receipt",
       "billKey": "ws-bill",
+      "arrears": true,
       "buttons": [
         {
           "label": "COMMON_BUTTON_HOME",
@@ -137,6 +147,7 @@
       "headerBandLabel": "PAYMENT_COMMON_APPLICATION_CODE",
       "receiptKey": "ws-onetime-receipt",
       "billKey": "ws-bill",
+      "arrears": true,
       "buttons": [
         {
           "label": "COMMON_BUTTON_HOME",
@@ -150,6 +161,7 @@
       "headerBandLabel": "PAYMENT_COMMON_APPLICATION_CODE",
       "receiptKey": "ws-onetime-receipt",
       "billKey": "ws-bill",
+      "arrears": true,
       "buttons": [
         {
           "label": "COMMON_BUTTON_HOME",
@@ -163,6 +175,7 @@
       "headerBandLabel": "PAYMENT_COMMON_CONSUMER_CODE",
       "receiptKey": "consolidatedreceipt",
       "billKey": "consolidatedbill",
+      "arrears": false,
       "buttons": [
         {
           "label": "COMMON_BUTTON_HOME",


### PR DESCRIPTION
RAIN-1586(Common Pay :: Arrears tax heads should not be displayed in the common pay screen if Arrears are not available for the modules.)