### PR TITLE
RAIN-3414 Added bulk pdf cancel process action

### DIFF
--- a/data/pb/ACCESSCONTROL-ACTIONS-TEST/actions-test.json
+++ b/data/pb/ACCESSCONTROL-ACTIONS-TEST/actions-test.json
@@ -10873,6 +10873,17 @@
       "serviceCode": "pdf-generator-create",
       "code": "null",
       "path": ""
+    },
+    {
+      "id": 2212,
+      "name": "Bulk PDF Cancel Process",
+      "url": "/pdf-service/v1/_cancelProcess",
+      "displayName": "Bulk PDF Cancel Process",
+      "orderNumber": 1,
+      "enabled": false,
+      "serviceCode": "pdf-generator-create",
+      "code": "null",
+      "path": ""
     }
   ]
 }   


### PR DESCRIPTION
RAIN-3414 Updated bulk pdf cancel process
{
      "id": 2212,
      "name": "Bulk PDF Cancel Process",
      "url": "/pdf-service/v1/_cancelProcess",
      "displayName": "Bulk PDF Cancel Process",
      "orderNumber": 1,
      "enabled": false,
      "serviceCode": "pdf-generator-create",
      "code": "null",
      "path": ""
    }